### PR TITLE
Use get_extension() with attachment file, not original post

### DIFF
--- a/filetype-taxonomy.php
+++ b/filetype-taxonomy.php
@@ -31,7 +31,11 @@ function wpdr_update_type( $postID ) {
 	if ( !$wpdr->verify_post_type( $postID ) )
 		return;
 		
-	wp_set_post_terms( $postID, array( $wpdr->get_extension( $postID ) ), 'filetype', false );
+	$post = get_post( $postID );
+	$attachment = get_post( $post->post_content );
+	$extensions = array( $wpdr->get_extension( get_attached_file( $attachment->ID ) ) ) ;
+	
+	wp_set_post_terms( $postID, $extensions, 'filetype', false );
 }
 
 add_action( 'save_post', 'wpdr_update_type', 10, 1 );


### PR DESCRIPTION
I tried to use this plugin but it didn't work. I noticed get_extension works against attached files, not the original post. So I write this little fix (which gets the attachment, and then apply get_extension). It seems to work now.
